### PR TITLE
Add Pale Moon compatibility

### DIFF
--- a/install.rdf
+++ b/install.rdf
@@ -22,6 +22,15 @@
       </Description>
     </em:targetApplication>
 
+    <!-- PaleMoon -->
+    <em:targetApplication>
+      <Description>
+        <em:id>{8de7fcbb-c55c-4fbe-bfc5-fc555c87dbc4}</em:id>
+        <em:minVersion>25.0</em:minVersion>
+        <em:maxVersion>30.*</em:maxVersion>
+      </Description>
+    </em:targetApplication>
+
     <!-- Android -->
     <em:targetApplication>
       <Description>


### PR DESCRIPTION
This adds Pale Moon GUID in order to address #17 . The add-on installs and works perfectly fine with Pale Moon with that change, and it doesn't have any impact on Firefox, since it will ignore PM's GUID.
